### PR TITLE
Update 2320ce7ce6b8e8.md(Juliaパッケージの標準的なディレクトリ構成) の修正

### DIFF
--- a/articles/2320ce7ce6b8e8.md
+++ b/articles/2320ce7ce6b8e8.md
@@ -522,7 +522,7 @@ https://github.com/JuliaRegistries/CompatHelper.jl/blob/master/.github/workflows
 ### `.github/workflows/TagBot.yml`
 
 パッケージをGeneralに登録したときに自動的にリリースを打つための設定。
-GitHub Actionsで[TagBot.jl](https://github.com/JuliaRegistries/TagBot.jl)を実行するための設定。
+GitHub Actionsで[TagBot](https://github.com/JuliaRegistries/TagBot)を実行するための設定。
 
 https://github.com/JuliaRegistries/TagBot#setup に書かれてあるコードをコピペすればOK。
 


### PR DESCRIPTION
TagBot は .jl がついてないのがURLとして正しいです． https://github.com/JuliaRegistries/TagBot のように修正しました．TagBot は Python 実装ですが https://github.com/JuliaRegistries/FutureTagBot.jl という WIP の Julia 実装はあるようです．